### PR TITLE
Removed as many sqrt calls as possible by abusing the fact that X*X <…

### DIFF
--- a/Activities/GameActivity.cpp
+++ b/Activities/GameActivity.cpp
@@ -1510,7 +1510,8 @@ void GameActivity::Update()
                     // Show the pie menu switching animation over the highlighted Actor
                     m_pPieMenu[player]->SetPos(pMarkedActor->GetPos());
 
-                    if (markedDistance.GetMagnitude() > g_FrameMan.GetPlayerFrameBufferWidth(player) / 4)
+                    int quarterFrameBuffer = g_FrameMan.GetPlayerFrameBufferWidth(player) / 4;
+                    if (markedDistance.GetSqrMagnitude() > quarterFrameBuffer*quarterFrameBuffer)
                         m_pPieMenu[player]->Wobble();
                     else
                         m_pPieMenu[player]->FreezeAtRadius(30);
@@ -1599,14 +1600,19 @@ void GameActivity::Update()
 
 			//Check if we crossed the seam
 			if (g_SceneMan.GetScene()->WrapsX())
-				if (relativeToActor.GetMagnitude() > sceneWidth / 2 && relativeToActor.GetMagnitude() > 350)
-					if (m_ActorCursor->m_X < sceneWidth / 2)
+            {
+                float halfSceneWidth = sceneWidth * 0.5F;
+				if (relativeToActor.GetSqrMagnitude() > halfSceneWidth*halfSceneWidth && relativeToActor.GetSqrMagnitude() > 350.0F*350.0F)
+                {
+					if (m_ActorCursor->m_X < halfSceneWidth)
 						relativeToActor = m_ActorCursor[player] + Vector(sceneWidth , 0) - m_ControlledActor[player]->GetPos();
 					else
 						relativeToActor = m_ActorCursor[player] - Vector(sceneWidth , 0) - m_ControlledActor[player]->GetPos();
-	
+                }
+            }
+
 			// Limit selection range
-			relativeToActor = relativeToActor.CapMagnitude(350);
+			relativeToActor = relativeToActor.CapMagnitude(350.0F);
 			m_ActorCursor[player] = m_ControlledActor[player]->GetPos() + relativeToActor;
 
             m_pPieMenu[player]->SetEnabled(false);
@@ -1649,7 +1655,7 @@ void GameActivity::Update()
 				m_ControlledActor[player]->SetAIMode(Actor::AIMODE_SENTRY);
 
 				// Detect nearby actors and attach them to commander
-				float radius = g_SceneMan.ShortestDistance(m_ActorCursor[player],m_ControlledActor[player]->GetPos(), true).GetMagnitude();
+				float sqrRadius = g_SceneMan.ShortestDistance(m_ActorCursor[player],m_ControlledActor[player]->GetPos(), true).GetSqrMagnitude();
 
 				Actor *pActor = 0;
 				Actor *pFirstActor = 0;
@@ -1664,7 +1670,7 @@ void GameActivity::Update()
 					{
 						// If human, set appropriate AI mode
 						if (dynamic_cast<AHuman *>(pActor) || dynamic_cast<ACrab *>(pActor))
-							if (g_SceneMan.ShortestDistance(m_ControlledActor[player]->GetPos(), pActor->GetPos(),true).GetMagnitude() < radius)
+							if (g_SceneMan.ShortestDistance(m_ControlledActor[player]->GetPos(), pActor->GetPos(),true).GetSqrMagnitude() < sqrRadius)
 							{
 								pActor->FlashWhite();
 								pActor->ClearAIWaypoints();
@@ -2495,10 +2501,11 @@ void GameActivity::DrawGUI(BITMAP *pTargetBitmap, const Vector &targetPos, int w
 				//Calculate unwrapped cursor position, or it won't glow
 				unwrappedPos = m_ActorCursor[PoS] - m_ControlledActor[PoS]->GetPos();
 				float sceneWidth = g_SceneMan.GetSceneWidth();
+                float halfSceneWidth = sceneWidth * 0.5F;
 				
-				if (unwrappedPos.GetMagnitude() > sceneWidth / 2 && unwrappedPos.GetMagnitude() > 350)
+				if (unwrappedPos.GetSqrMagnitude() > halfSceneWidth*halfSceneWidth && unwrappedPos.GetSqrMagnitude() > 350*350)
 				{
-					if (m_ActorCursor->m_X < sceneWidth / 2)
+					if (m_ActorCursor->m_X < halfSceneWidth)
 						unwrappedPos = m_ActorCursor[PoS] + Vector(sceneWidth , 0);
 					else
 						unwrappedPos = m_ActorCursor[PoS] - Vector(sceneWidth , 0);

--- a/Entities/ACDropShip.cpp
+++ b/Entities/ACDropShip.cpp
@@ -425,7 +425,7 @@ void ACDropShip::UpdateAI()
     /////////////////////////
     // If we are hopelessly stuck, self destruct
 
-    if (m_RecentMovementMag > 10)
+    if (m_RecentMovement.GetSqrMagnitude() > 10.0F*10.0F)
         m_StuckTimer.Reset();
     if (m_StuckTimer.IsPastSimMS(10000))
         GibThis();

--- a/Entities/ACRocket.cpp
+++ b/Entities/ACRocket.cpp
@@ -309,7 +309,6 @@ bool ACRocket::OnSink(const Vector &pos)
 
 void ACRocket::UpdateAI()
 {
-    float velMag = m_Vel.GetMagnitude();
     float angle = m_Rotation.GetRadAngle();
 
     // This is the limit where increased thrust should be applied to assure a soft landing
@@ -320,7 +319,8 @@ void ACRocket::UpdateAI()
     float altitude = GetAltitude(g_SceneMan.GetSceneHeight() / 2, 10);
 
     // Stuck detection
-    if (velMag > 1.0)
+    float moveThreshold = 1.0f;
+    if (m_Vel.GetSqrMagnitude() > moveThreshold*moveThreshold)
         m_StuckTimer.Reset();
 
     /////////////////////////////
@@ -429,7 +429,7 @@ void ACRocket::UpdateAI()
     // STABILIZATION
 
     // Don't mess if we're unloading or automatically stabilizing
-    if (AutoStabilizing() || (m_DeliveryState == UNLOAD && velMag < 5.0))
+    if (AutoStabilizing() || (m_DeliveryState == UNLOAD && m_Vel.GetSqrMagnitude() < 5.0f*5.0F))
         m_LateralMoveState = LAT_STILL;
     else
     {

--- a/Entities/ACraft.cpp
+++ b/Entities/ACraft.cpp
@@ -176,13 +176,15 @@ MOSRotating * ACraft::Exit::SuckInMOs(ACraft *pExitOwner)
     // If we're sucking on an MO already
     if (m_pIncomingMO)
     {
+        const float rangeAndAHalf = m_Range * 1.5F;
+
         // Check that it's still active and valid (not destroyed)
         if (!(g_MovableMan.IsDevice(m_pIncomingMO) || g_MovableMan.IsActor(m_pIncomingMO)))
         {
             m_pIncomingMO = 0;
         }
         // See if it's now out of range of suckage
-        else if ((exitPos - m_pIncomingMO->GetPos()).GetMagnitude() > (m_Range * 1.5))
+        else if ((exitPos - m_pIncomingMO->GetPos()).GetSqrMagnitude() > rangeAndAHalf*rangeAndAHalf)
         {
             m_pIncomingMO = 0;
         }
@@ -201,7 +203,8 @@ MOSRotating * ACraft::Exit::SuckInMOs(ACraft *pExitOwner)
             // Figure the distance left for the object to go to reach the exit
             Vector toGo = exitPos - m_pIncomingMO->GetPos();
             // If the object is still a bit away from the exit goal, override velocity of the object to head straight into the exit
-            if (toGo.GetMagnitude() > 1.0f)
+            const float threshold = 1.0F;
+            if (toGo.GetSqrMagnitude() > threshold*threshold)
                 m_pIncomingMO->SetVel(toGo.SetMagnitude(m_Velocity.GetMagnitude()));
 
             // Turn off collisions between the object and the craft sucking it in
@@ -892,12 +895,12 @@ void ACraft::Update()
     // Set viewpoint based on how we are aiming etc.
     m_ViewPoint = m_Pos.GetFloored();
 	// Add velocity also so the viewpoint moves ahead at high speeds
-	if (m_Vel.GetMagnitude() > 10) { m_ViewPoint += m_Vel * std::sqrt(m_Vel.GetMagnitude() * 0.1F); }
+	if (m_Vel.GetSqrMagnitude() > 10.0F*10.0F) { m_ViewPoint += m_Vel * std::sqrt(m_Vel.GetMagnitude() * 0.1F); }
 
     ///////////////////////////////////////////////////
     // Crash detection and handling
-
-    if (m_DeepHardness > 5 && m_Vel.GetMagnitude() > 1.0)
+    const float crashSpeedThreshold = 1.0F;
+    if (m_DeepHardness > 5 && m_Vel.GetSqrMagnitude() > crashSpeedThreshold*crashSpeedThreshold)
     {
         m_Health -= m_DeepHardness * 0.03;
 // TODO: HELLA GHETTO, REWORK

--- a/Entities/AHuman.cpp
+++ b/Entities/AHuman.cpp
@@ -1626,10 +1626,10 @@ bool AHuman::IsWithinRange(Vector &point) const
         return true;
 
     Vector diff = g_SceneMan.ShortestDistance(m_Pos, point, false);
-    float distance = diff.GetMagnitude();
+    float sqrDistance = diff.GetSqrMagnitude();
 
     // Really close!
-    if (distance <= m_CharHeight)
+    if (sqrDistance <= m_CharHeight*m_CharHeight)
         return true;
 
     float range = 0;
@@ -1649,7 +1649,7 @@ bool AHuman::IsWithinRange(Vector &point) const
         range += m_CharHeight * 4;
     }
 
-    return distance <= range;
+    return sqrDistance <= range*range;
 }
 
 
@@ -2061,7 +2061,7 @@ void AHuman::UpdateAI()
                 // Only replace the target if the one we found is closer, or the old one isn't gold anymore
                 Vector newGoldDir = newGoldPos - m_Pos;
                 Vector oldGoldDir = m_DigTarget - m_Pos;
-                if (newGoldDir.GetMagnitude() < oldGoldDir.GetMagnitude() || g_SceneMan.GetTerrain()->GetMaterialPixel(m_DigTarget.m_X, m_DigTarget.m_Y) != g_MaterialGold)
+                if (newGoldDir.GetSqrMagnitude() < oldGoldDir.GetSqrMagnitude() || g_SceneMan.GetTerrain()->GetMaterialPixel(m_DigTarget.m_X, m_DigTarget.m_Y) != g_MaterialGold)
                 {
                     m_DigTarget = newGoldPos;
                     m_StuckTimer.Reset();
@@ -2476,9 +2476,9 @@ void AHuman::UpdateAI()
                 {
                     // Get the distance to the target and see if we've aimed well enough
                     Vector targetVec = g_SceneMan.ShortestDistance(m_Pos, m_SeenTargetPos, false);
-                    float distance = targetVec.GetMagnitude();
+                    float threshold = (m_AimDistance * 6.0F) + (m_pFGArm->GetHeldDevice()->GetSharpLength() * m_SharpAimProgress);
                     // Fire if really close, or if we have aimed well enough
-                    if (distance < m_AimDistance * 6 + m_pFGArm->GetHeldDevice()->GetSharpLength() * m_SharpAimProgress)
+                    if (targetVec.GetSqrMagnitude() < threshold*threshold)
                     {
                         // ENEMY AIMED AT well enough - FIRE!
                         m_DeviceState = FIRING;
@@ -3010,7 +3010,7 @@ void AHuman::UpdateAI()
     if (m_ObstacleState == PROCEEDING)
     {
         // Reset stuck timer if we're moving fine, or we're waiting for teammate to move
-        if (m_RecentMovementMag > 2.5 || m_TeamBlockState)
+        if (m_RecentMovement.GetSqrMagnitude() > 2.5F*2.5F || m_TeamBlockState)
             m_StuckTimer.Reset();
 
         if (m_DeviceState == SCANNING)
@@ -3034,7 +3034,7 @@ void AHuman::UpdateAI()
     if (m_ObstacleState == JUMPING)
     {
         // Reset stuck timer if we're moving fine
-        if (m_RecentMovementMag > 2.5)
+        if (m_RecentMovement.GetSqrMagnitude() > 2.5F*2.5F)
             m_StuckTimer.Reset();
 
         if (m_StuckTimer.IsPastSimMS(250))
@@ -3063,7 +3063,7 @@ void AHuman::UpdateAI()
     }
     // Reset from backstepping
 // TODO: better movement detection
-    else if (m_ObstacleState == BACKSTEPPING && (m_StuckTimer.IsPastSimMS(2000) || m_RecentMovementMag > 15.0))
+    else if (m_ObstacleState == BACKSTEPPING && (m_StuckTimer.IsPastSimMS(2000) || m_RecentMovement.GetSqrMagnitude() > 15.0F*15.0F))
     {
         m_ObstacleState = PROCEEDING;
         m_StuckTimer.Reset();
@@ -3147,7 +3147,9 @@ void AHuman::Update()
 {
 	float deltaTime = g_TimerMan.GetDeltaTimeSecs();
 	float rot = m_Rotation.GetRadAngle();
+	
 	Vector analogAim = m_Controller.GetAnalogAim();
+    const float analogDeadzone = 0.1F;
 
 	m_Paths[FGROUND][m_MoveState].SetHFlip(m_HFlipped);
 	m_Paths[BGROUND][m_MoveState].SetHFlip(m_HFlipped);
@@ -3183,7 +3185,7 @@ void AHuman::Update()
 		// If pie menu is on, keep the angle to what it was before.
 		if (!m_Controller.IsState(PIE_MENU_ACTIVE)) {
 			// Direct the jetpack nozzle according to either analog stick input or aim angle.
-			if (m_Controller.GetAnalogMove().GetMagnitude() > 0.1F) {
+			if (m_Controller.GetAnalogMove().GetSqrMagnitude() > analogDeadzone*analogDeadzone) {
 				float jetAngle = std::clamp(m_Controller.GetAnalogMove().GetAbsRadAngle() - c_HalfPI, -maxAngle, maxAngle);
 				m_pJetpack->SetEmitAngle(FacingAngle(jetAngle - c_HalfPI));
 			} else {
@@ -3200,8 +3202,8 @@ void AHuman::Update()
 
 	////////////////////////////////////
 	// Movement direction
-
-	bool isStill = (m_Vel + m_PrevVel).GetMagnitude() < 1.0F;
+    const float movementThreshold = 1.0f;
+	bool isStill = (m_Vel + m_PrevVel).GetSqrMagnitude() < movementThreshold*movementThreshold;
 	bool isSharpAiming = m_Controller.IsState(AIM_SHARP);
 
 	// If the pie menu is on, try to preserve whatever move state we had before it going into effect.
@@ -3233,7 +3235,7 @@ void AHuman::Update()
 			}
 
 			// Walk backwards if the aiming is already focused in the opposite direction of travel.
-			if (analogAim.GetMagnitude() != 0 || isSharpAiming) {
+			if (analogAim.GetSqrMagnitude() > analogDeadzone*analogDeadzone || isSharpAiming) {
 				m_Paths[FGROUND][m_MoveState].SetHFlip(m_Controller.IsState(MOVE_LEFT));
 				m_Paths[BGROUND][m_MoveState].SetHFlip(m_Controller.IsState(MOVE_LEFT));
 			} else if ((m_Controller.IsState(MOVE_RIGHT) && m_HFlipped) || (m_Controller.IsState(MOVE_LEFT) && !m_HFlipped)) {
@@ -3332,7 +3334,7 @@ void AHuman::Update()
 		m_AimAngle -= isSharpAiming ? std::min(static_cast<float>(m_AimTmr.GetElapsedSimTimeMS()) * 0.00005F, 0.05F) : std::min(static_cast<float>(m_AimTmr.GetElapsedSimTimeMS()) * 0.00015F, 0.15F) * m_Controller.GetDigitalAimSpeed();
 		if (m_AimAngle < -m_AimRange) { m_AimAngle = -m_AimRange; }
 
-	} else if (analogAim.GetMagnitude() != 0 && m_Status != INACTIVE) {
+	} else if (analogAim.GetSqrMagnitude() > analogDeadzone*analogDeadzone && m_Status != INACTIVE) {
 		// Hack to avoid the GetAbsRadAngle from mangling an aim angle straight down.
 		if (analogAim.m_X == 0) { analogAim.m_X += 0.01F * GetFlipFactor(); }
 		m_AimAngle = analogAim.GetAbsRadAngle();
@@ -3365,7 +3367,7 @@ void AHuman::Update()
 
 // TODO: make the delay data driven by both the actor and the device!
     // 
-	if (isSharpAiming && m_Status == STABLE && (m_MoveState == STAND || m_MoveState == CROUCH || m_MoveState == NOMOVE || m_MoveState == WALK) && m_Vel.GetMagnitude() < 5.0F && GetEquippedItem()) {
+	if (isSharpAiming && m_Status == STABLE && (m_MoveState == STAND || m_MoveState == CROUCH || m_MoveState == NOMOVE || m_MoveState == WALK) && m_Vel.GetSqrMagnitude() < 5.0F*5.0F && GetEquippedItem()) {
         float aimMag = analogAim.GetMagnitude();
 
 		// If aim sharp is being done digitally, then translate to full analog aim mag
@@ -3589,9 +3591,14 @@ void AHuman::Update()
 	}
 
     // Item currently set to be within reach has expired or is now out of range
-    if (m_pItemInReach && (!m_pFGArm || m_pItemInReach->IsUnPickupable() || (m_pItemInReach->HasPickupLimitations() && !m_pItemInReach->IsPickupableBy(this)) || !g_MovableMan.IsDevice(m_pItemInReach) || g_SceneMan.ShortestDistance(reachPoint, m_pItemInReach->GetPos(), g_SceneMan.SceneWrapsX()).GetMagnitude() > reach + m_pItemInReach->GetRadius())) {
-        m_pItemInReach = nullptr;
-        m_PieNeedsUpdate = true;
+    if (m_pItemInReach) 
+    {
+        const float reachAndItemReachRadius = reach + m_pItemInReach->GetRadius();
+        if ((!m_pFGArm || m_pItemInReach->IsUnPickupable() || (m_pItemInReach->HasPickupLimitations() && !m_pItemInReach->IsPickupableBy(this)) || !g_MovableMan.IsDevice(m_pItemInReach) || g_SceneMan.ShortestDistance(reachPoint, m_pItemInReach->GetPos(), g_SceneMan.SceneWrapsX()).GetSqrMagnitude() > reachAndItemReachRadius*reachAndItemReachRadius))
+        {
+            m_pItemInReach = nullptr;
+            m_PieNeedsUpdate = true;
+        }
     }
 
 	if (m_pItemInReach && m_pFGArm && m_Controller.IsState(WEAPON_PICKUP) && m_Status != INACTIVE && g_MovableMan.RemoveMO(m_pItemInReach)) {
@@ -3966,7 +3973,7 @@ void AHuman::Update()
     m_ViewPoint = m_Pos.GetFloored() + aimSight;
 
 	// Add velocity also so the viewpoint moves ahead at high speeds
-	if (m_Vel.GetMagnitude() > 10.0F) { m_ViewPoint += m_Vel * std::sqrt(m_Vel.GetMagnitude() * 0.1F); }
+	if (m_Vel.GetSqrMagnitude() > 10.0F*10.0F) { m_ViewPoint += m_Vel * std::sqrt(m_Vel.GetMagnitude() * 0.1F); }
 
 
 /* Done by pie menu now, see HandlePieCommand()

--- a/Entities/Activity.cpp
+++ b/Entities/Activity.cpp
@@ -719,7 +719,8 @@ void Activity::Clear() {
 		SoundContainer *actorSwitchSoundToPlay = (m_ControlledActor[player] == m_Brain[player]) ? g_GUISound.BrainSwitchSound() : g_GUISound.ActorSwitchSound();
 		actorSwitchSoundToPlay->Play(player);
 
-		if (preSwitchActor && g_SceneMan.ShortestDistance(preSwitchActor->GetPos(), m_ControlledActor[player]->GetPos(), g_SceneMan.SceneWrapsX() || g_SceneMan.SceneWrapsY()).GetMagnitude() > g_FrameMan.GetResX() / 2) {
+		const int halfXRes = g_FrameMan.GetResX() / 2;
+		if (preSwitchActor && g_SceneMan.ShortestDistance(preSwitchActor->GetPos(), m_ControlledActor[player]->GetPos(), g_SceneMan.SceneWrapsX() || g_SceneMan.SceneWrapsY()).GetSqrMagnitude() > halfXRes*halfXRes) {
 			g_GUISound.CameraTravelSound()->Play(player);
 		}
 

--- a/Entities/Actor.h
+++ b/Entities/Actor.h
@@ -1385,7 +1385,6 @@ protected:
     Vector m_LastSecondPos;
     // Movement since last whole second
     Vector m_RecentMovement;
-    float m_RecentMovementMag;
     // Threshold for taking damage from travel impulses, in kg * m/s
     float m_TravelImpulseDamage;
     // Timer for timing the delay before regaining stability after losing it
@@ -1539,9 +1538,9 @@ protected:
     TeamBlockState m_TeamBlockState;
     // Times how long after an obstruction is cleared to start proceeding again
     Timer m_BlockTimer;
-    // The closest the actor has ever come to the current waypoint it's going for. Used to checking if we shuold re-update the movepath
+    // The closest the actor has ever come to the current waypoint it's going for, squared. Used to checking if we shuold re-update the movepath
     // It's useful for when the path seems to be broken or unreachable
-    float m_BestTargetProximity;
+    float m_BestTargetProximitySqr;
     // Timer used to check on larger movement progress toward the goal
     Timer m_ProgressTimer;
     // Timer used to time how long we've been stuck in the same spot.

--- a/Entities/Arm.cpp
+++ b/Entities/Arm.cpp
@@ -310,9 +310,11 @@ void Arm::Reach(const Vector &scenePoint)
     else
         m_Pos += m_ParentOffset;
 
+    float reachSqrMagnitude = reachVec.GetSqrMagnitude();
     Vector reachVec(m_TargetPosition - m_Pos);
-    return reachVec.GetMagnitude() <= m_MaxLength &&
-           reachVec.GetMagnitude() >= (m_MaxLength / 2);
+    const float halfMaxLength = m_MaxLength * 0.5F;
+    return reachSqrMagnitude <= m_MaxLength*m_MaxLength &&
+           reachSqrMagnitude >= halfMaxLength*halfMaxLength;
 */
 }
 
@@ -415,7 +417,7 @@ void Arm::UpdateCurrentHandOffset() {
             } else {
                 targetOffset = g_SceneMan.ShortestDistance(m_JointPos, m_TargetPosition, g_SceneMan.SceneWrapsX());
                 m_DidReach = m_WillIdle;
-                if (m_WillIdle && targetOffset.GetMagnitude() > m_MaxLength) {
+                if (m_WillIdle && targetOffset.GetSqrMagnitude() > m_MaxLength*m_MaxLength) {
                     targetOffset = m_IdleOffset.GetXFlipped(m_HFlipped);
                     m_DidReach = false;
                 }

--- a/Entities/Attachable.cpp
+++ b/Entities/Attachable.cpp
@@ -207,12 +207,12 @@ namespace RTE {
 		}
 		totalImpulseForce *= jointStiffnessValueToUse;
 
-		float totalImpulseForceMagnitude = totalImpulseForce.GetMagnitude();
-		if (gibImpulseLimitValueToUse > 0 && totalImpulseForceMagnitude > gibImpulseLimitValueToUse) {
+		float totalImpulseForceSqrMagnitude = totalImpulseForce.GetSqrMagnitude();
+		if (gibImpulseLimitValueToUse > 0 && totalImpulseForceSqrMagnitude > gibImpulseLimitValueToUse*gibImpulseLimitValueToUse) {
 			jointImpulses += totalImpulseForce.SetMagnitude(gibImpulseLimitValueToUse);
 			GibThis();
 			return false;
-		} else if (jointStrengthValueToUse > 0 && totalImpulseForceMagnitude > jointStrengthValueToUse) {
+		} else if (jointStrengthValueToUse > 0 && totalImpulseForceSqrMagnitude > jointStrengthValueToUse*jointStrengthValueToUse) {
 			jointImpulses += totalImpulseForce.SetMagnitude(jointStrengthValueToUse);
 			m_Parent->RemoveAttachable(this, true, true);
 			return false;

--- a/Entities/Deployment.cpp
+++ b/Entities/Deployment.cpp
@@ -383,8 +383,8 @@ bool Deployment::DeploymentBlocked(int player, const list<SceneObject *> &existi
 				// Do ghetto distance calc between the thing we want to place and the similar thing we found already placed
 				// Note this doesn't take into account Scene wrapping, which is problematic when the Scene might not be loaded.. it's okay in this case though
 				Vector distance = (*existingItr)->GetPos() - m_Pos;
-				// If the same thing is within the spawn radius, then signal that this Deployment location is indeed BLOCKED
-				if (distance.GetMagnitude() < m_WalkRadius)
+				// If the same thing is within the walk radius, then signal that this Deployment location is indeed BLOCKED
+				if (distance.GetSqrMagnitude() < m_WalkRadius*m_WalkRadius)
 				{
 					blocked = true;
 					break;
@@ -470,7 +470,7 @@ bool Deployment::DeploymentBlocked(int player, const list<SceneObject *> &existi
                 // Note this doesn't take into account Scene wrapping, which is problematic when the Scene might not be loaded.. it's okay in this case though
                 Vector distance = (*existingItr)->GetPos() - m_Pos;
                 // If the same thing is within the spawn radius, then signal that this Deployment location is indeed BLOCKED
-                if (distance.GetMagnitude() < m_SpawnRadius)
+                if (distance.GetSqrMagnitude() < m_SpawnRadius*m_SpawnRadius)
                 {
                     blocked = true;
                     break;

--- a/Entities/HeldDevice.cpp
+++ b/Entities/HeldDevice.cpp
@@ -584,7 +584,7 @@ void HeldDevice::DrawHUD(BITMAP *pTargetBitmap, const Vector &targetPos, int whi
 				}
 				// Note - to avoid item HUDs flickering in and out, we need to add a little leeway when hiding them if they're already displayed.
 				if (m_SeenByPlayer.at(viewingPlayer) && unheldItemDisplayRange > 0) { unheldItemDisplayRange += 3.0F; }
-				m_SeenByPlayer.at(viewingPlayer) = unheldItemDisplayRange < 0 || (unheldItemDisplayRange > 0 && g_SceneMan.ShortestDistance(m_Pos, g_SceneMan.GetScrollTarget(whichScreen), g_SceneMan.SceneWrapsX()).GetMagnitude() < unheldItemDisplayRange);
+				m_SeenByPlayer.at(viewingPlayer) = unheldItemDisplayRange < 0 || (unheldItemDisplayRange > 0 && g_SceneMan.ShortestDistance(m_Pos, g_SceneMan.GetScrollTarget(whichScreen), g_SceneMan.SceneWrapsX()).GetSqrMagnitude() < unheldItemDisplayRange*unheldItemDisplayRange);
 
 				if (m_SeenByPlayer.at(viewingPlayer)) {
 					char pickupArrowString[64];

--- a/Entities/Leg.cpp
+++ b/Entities/Leg.cpp
@@ -39,7 +39,7 @@ namespace RTE {
 		// Ensure Legs don't collide with terrain when attached since their expansion/contraction is frame based so atom group doesn't know how to account for it.
 		SetCollidesWithTerrainWhileAttached(false);
 
-		if (m_ContractedOffset.GetMagnitude() > m_ExtendedOffset.GetMagnitude()) { std::swap(m_ContractedOffset, m_ExtendedOffset); }
+		if (m_ContractedOffset.GetSqrMagnitude() > m_ExtendedOffset.GetSqrMagnitude()) { std::swap(m_ContractedOffset, m_ExtendedOffset); }
 
 		m_MinExtension = m_ContractedOffset.GetMagnitude();
 		m_MaxExtension = m_ExtendedOffset.GetMagnitude();

--- a/Entities/LimbPath.cpp
+++ b/Entities/LimbPath.cpp
@@ -308,7 +308,7 @@ Vector LimbPath::GetCurrentVel(const Vector &limbPos)
         returnVel.CapMagnitude(adjustedTravelSpeed);
         returnVel += m_JointVel;
 
-//        if (distVect.GetMagnitude() < 0.5)
+//        if (distVect.GetSqrMagnitude() < 0.5F*0.5F)
 //            returnVel *= 0.1;
     }
     else
@@ -375,7 +375,8 @@ void LimbPath::ReportProgress(const Vector &limbPos)
 {
     if (IsStaticPoint())
     {
-        m_Ended = g_SceneMan.ShortestDistance(limbPos, GetCurrentSegTarget()).GetMagnitude() < 1.0;
+        const float threshold = 1.0F;
+        m_Ended = g_SceneMan.ShortestDistance(limbPos, GetCurrentSegTarget()).GetSqrMagnitude() < threshold*threshold;
     }
     else
     {
@@ -441,7 +442,7 @@ float LimbPath::GetTotalProgress() const
 // Method:          GetRegularProgress
 //////////////////////////////////////////////////////////////////////////////////////////
 // Description:     Gets a value representing the progress that has been made on the
-//                  regular part of this path, ie averythign except the starting segments.
+//                  regular part of this path, ie everything except the starting segments.
 //                  If progress has not been made past the starting segments, < 0 will
 //                  be returned. If the path has ended, 0.0 is returned.
 

--- a/Entities/MOSRotating.cpp
+++ b/Entities/MOSRotating.cpp
@@ -713,7 +713,7 @@ bool MOSRotating::CollideAtPoint(HitData &hd)
         // If the hittee is pinned, see if the collision's impulse is enough to dislodge it.
         float hiteePin = hd.Body[HITEE]->GetPinStrength();
         // See if it's pinned, and compare it to the impulse force from the collision
-        if (m_PinStrength > 0 && hd.ResImpulse[HITEE].GetMagnitude() > m_PinStrength)
+        if (m_PinStrength > 0 && hd.ResImpulse[HITEE].GetSqrMagnitude() > m_PinStrength*m_PinStrength)
         {
             // Unpin and set the threshold to 0
             hd.Body[HITEE]->SetPinStrength(0);
@@ -788,7 +788,6 @@ bool MOSRotating::ParticlePenetration(HitData &hd)
     float impulseForce = hd.ResImpulse[HITEE].GetMagnitude();
     Material const * myMat = GetMaterial();
     float myStrength = myMat->GetIntegrity() / hd.Body[HITOR]->GetSharpness();
-
 
     // See if there is enough energy in the collision for the particle to penetrate
     if (impulseForce * hd.Body[HITOR]->GetSharpness() > myMat->GetIntegrity())
@@ -1180,7 +1179,7 @@ void MOSRotating::ApplyImpulses()
 		if (m_WoundCountAffectsImpulseLimitRatio != 0 && m_GibWoundLimit > 0) {
 			impulseLimit *= 1.0F - (static_cast<float>(m_Wounds.size()) / static_cast<float>(m_GibWoundLimit)) * m_WoundCountAffectsImpulseLimitRatio;
 		}
-		if (totalImpulse.GetMagnitude() > impulseLimit) { GibThis(totalImpulse); }
+		if (totalImpulse.GetSqrMagnitude() > impulseLimit*impulseLimit) { GibThis(totalImpulse); }
 	}
     MOSprite::ApplyImpulses();
 }
@@ -1458,7 +1457,7 @@ void MOSRotating::PostTravel()
 		if (m_WoundCountAffectsImpulseLimitRatio != 0 && m_GibWoundLimit > 0) {
 			impulseLimit *= 1.0F - (static_cast<float>(m_Wounds.size()) / static_cast<float>(m_GibWoundLimit)) * m_WoundCountAffectsImpulseLimitRatio;
 		}
-		if (m_TravelImpulse.GetMagnitude() > impulseLimit) { GibThis(); }
+		if (m_TravelImpulse.GetSqrMagnitude() > impulseLimit*impulseLimit) { GibThis(); }
 	}
     // Reset
     m_DeepHardness = 0;
@@ -1562,12 +1561,8 @@ bool MOSRotating::DrawMOIDIfOverlapping(MovableObject *pOverlapMO)
         float combinedRadii = GetRadius() + pOverlapMO->GetRadius();
         Vector otherPos = pOverlapMO->GetPos();
 
-        // Quick check
-        if (fabs(otherPos.m_X - m_Pos.m_X) > combinedRadii || fabs(otherPos.m_Y - m_Pos.m_Y) > combinedRadii)
-            return false;
-
         // Check if the offset is within the combined radii of the two object, and therefore might be overlapping
-        if (g_SceneMan.ShortestDistance(m_Pos, otherPos, g_SceneMan.SceneWrapsX()).GetMagnitude() < combinedRadii)
+        if (g_SceneMan.ShortestDistance(m_Pos, otherPos, g_SceneMan.SceneWrapsX()).GetSqrMagnitude() < combinedRadii*combinedRadii)
         {
             // They may be overlapping, so draw the MOID rep of this to the MOID layer
             Draw(g_SceneMan.GetMOIDBitmap(), Vector(), g_DrawMOID, true);

--- a/Entities/Scene.cpp
+++ b/Entities/Scene.cpp
@@ -2123,7 +2123,7 @@ const SceneObject * Scene::PickPlacedObject(int whichSet, Vector &scenePoint, in
 const SceneObject * Scene::PickPlacedActorInRange(int whichSet, Vector &scenePoint, int range, int *pListOrderPlace) const
 {
 	SceneObject * pFoundObject = 0;
-	float distance = range;
+	float distanceSqr = range*range;
 	
 	// REVERSE!
     int i = m_PlacedObjects[whichSet].size() - 1;
@@ -2131,12 +2131,12 @@ const SceneObject * Scene::PickPlacedActorInRange(int whichSet, Vector &scenePoi
     {
 		if (dynamic_cast<const Actor *>(*itr))
 		{
-			float d = g_SceneMan.ShortestDistance((*itr)->GetPos(), scenePoint, true).GetMagnitude();
-			if (d < distance)
+			float checkDistanceSqr = g_SceneMan.ShortestDistance((*itr)->GetPos(), scenePoint, true).GetSqrMagnitude();
+			if (checkDistanceSqr < distanceSqr)
 			{
 				if (pListOrderPlace)
 					*pListOrderPlace = i;
-				distance = d;
+				distanceSqr = checkDistanceSqr;
 				pFoundObject = *itr;
 			}
 		}

--- a/GUI/AllegroInput.cpp
+++ b/GUI/AllegroInput.cpp
@@ -235,7 +235,7 @@ namespace RTE {
 		Vector joyKeyDirectional = g_UInputMan.GetMenuDirectional() * 5;
 
 		// See how much to accelerate the joystick input based on how long the stick has been pushed around
-		if (joyKeyDirectional.GetMagnitude() < 0.95F) { m_CursorAccelTimer->Reset(); }
+		if (joyKeyDirectional.GetSqrMagnitude() < 0.95F*0.95F) { m_CursorAccelTimer->Reset(); }
 
 		float acceleration = 0.25F + static_cast<float>(std::min(m_CursorAccelTimer->GetElapsedRealTimeS(), 0.5)) * 20.0F;
 

--- a/Managers/AudioMan.cpp
+++ b/Managers/AudioMan.cpp
@@ -721,10 +721,11 @@ namespace RTE {
 			float channel3dLevel;
 			result = (result == FMOD_OK) ? soundChannel->get3DLevel(&channel3dLevel) : result;
 			if (result == FMOD_OK && m_CurrentActivityHumanPlayerPositions.size() == 1) {
-				float distanceToPlayer = (*(m_CurrentActivityHumanPlayerPositions.at(0).get()) - GetAsVector(channelPosition)).GetMagnitude();
-				if (distanceToPlayer < m_MinimumDistanceForPanning) {
+				float sqrDistanceToPlayer = (*(m_CurrentActivityHumanPlayerPositions.at(0).get()) - GetAsVector(channelPosition)).GetSqrMagnitude();
+				float doubleMinimumDistanceForPanning = m_MinimumDistanceForPanning * 2.0F;
+				if (sqrDistanceToPlayer < m_MinimumDistanceForPanning*m_MinimumDistanceForPanning) {
 					soundChannel->set3DLevel(0);
-				} else if (distanceToPlayer < m_MinimumDistanceForPanning * 2) {
+				} else if (sqrDistanceToPlayer < doubleMinimumDistanceForPanning*doubleMinimumDistanceForPanning) {
 					soundChannel->set3DLevel(LERP(0, 1, 0, m_SoundPanningEffectStrength, channel3dLevel));
 				} else {
 					soundChannel->set3DLevel(m_SoundPanningEffectStrength);
@@ -765,21 +766,23 @@ namespace RTE {
 				wrappedChannelPositions = {FMOD_VECTOR({channelPosition.x - g_SceneMan.GetSceneWidth(), channelPosition.y}), channelPosition};
 		}
 
-		float shortestDistance = c_SoundMaxAudibleDistance;
-		float longestDistance = 0;
+		float shortestDistanceSqr = c_SoundMaxAudibleDistance*c_SoundMaxAudibleDistance;
+		float longestDistanceSqr = 0.0F;
 		for (const std::unique_ptr<const Vector> & humanPlayerPosition : m_CurrentActivityHumanPlayerPositions) {
 			for (const FMOD_VECTOR &wrappedChannelPosition : wrappedChannelPositions) {
-				float distanceToChannelPosition = (*(humanPlayerPosition.get()) - GetAsVector(wrappedChannelPosition)).GetMagnitude();
-				if (distanceToChannelPosition < shortestDistance) {
-					shortestDistance = distanceToChannelPosition;
+				float distanceToChannelPositionSqr = (*(humanPlayerPosition.get()) - GetAsVector(wrappedChannelPosition)).GetSqrMagnitude();
+				if (distanceToChannelPositionSqr < shortestDistanceSqr) {
+					shortestDistanceSqr = distanceToChannelPositionSqr;
 					channelPosition = wrappedChannelPosition;
 				}
-				if (distanceToChannelPosition > longestDistance) { longestDistance = distanceToChannelPosition; }
+				if (distanceToChannelPositionSqr > longestDistanceSqr) { longestDistanceSqr = distanceToChannelPositionSqr; }
 				if (!sceneWraps) {
 					break;
 				}
 			}
 		}
+
+		float shortestDistance = std::sqrt(shortestDistanceSqr);
 
 		int soundChannelIndex;
 		result = result == FMOD_OK ? soundChannel->getIndex(&soundChannelIndex) : result;
@@ -787,13 +790,14 @@ namespace RTE {
 		float attenuationStartDistance = c_DefaultAttenuationStartDistance;
 		float soundMaxDistance;
 		result = result == FMOD_OK ? soundChannel->get3DMinMaxDistance(&attenuationStartDistance, &soundMaxDistance) : result;
-		
+
 		float attenuatedVolume = (shortestDistance <= attenuationStartDistance) ? 1.0F : attenuationStartDistance / shortestDistance;
+		float longestDistance = m_SoundChannelMinimumAudibleDistances.at(soundChannelIndex);
 		if (shortestDistance >= soundMaxDistance) {
 			attenuatedVolume = 0.0F;
 		} else if (m_SoundChannelMinimumAudibleDistances.empty() || m_SoundChannelMinimumAudibleDistances.find(soundChannelIndex) == m_SoundChannelMinimumAudibleDistances.end()) {
 			g_ConsoleMan.PrintString("ERROR: An error occurred when checking to see if the sound at channel " + std::to_string(soundChannelIndex) + " was less than its minimum audible distance away from the farthest listener.");
-		} else if (longestDistance < m_SoundChannelMinimumAudibleDistances.at(soundChannelIndex)) {
+		} else if (longestDistanceSqr < longestDistance*longestDistance) {
 			attenuatedVolume = 0.0F;
 		}
 

--- a/Managers/UInputMan.cpp
+++ b/Managers/UInputMan.cpp
@@ -957,7 +957,7 @@ namespace RTE {
 					if (inputElements->at(elementsToCheck.at(i)).JoyDirMapped()) { aimValues.m_X = AnalogAxisValue(joystick, inputElements->at(elementsToCheck.at(i)).GetStick(), inputElements->at(elementsToCheck.at(i)).GetAxis()); }
 					if (inputElements->at(elementsToCheck.at(i + 1)).JoyDirMapped()) { aimValues.m_Y = AnalogAxisValue(joystick, inputElements->at(elementsToCheck.at(i + 1)).GetStick(), inputElements->at(elementsToCheck.at(i + 1)).GetAxis()); }
 
-					if (aimValues.GetMagnitude() < deadZone * 2) {
+					if (aimValues.GetSqrMagnitude() < (deadZone * 2.0f)*(deadZone * 2.0f)) {
 						for (int j = 0; j < 2; j++) {
 							InputElements whichElementDirection = elementsToCheck[i + j];
 							if (inputElements->at(whichElementDirection).JoyDirMapped()) {

--- a/Menus/AreaEditorGUI.cpp
+++ b/Menus/AreaEditorGUI.cpp
@@ -267,9 +267,9 @@ void AreaEditorGUI::Update()
     // Analog cursor input
 
     Vector analogInput;
-    if (m_pController->GetAnalogMove().GetMagnitude() > 0.1)
+    if (m_pController->GetAnalogMove().GetSqrMagnitude() > 0.1F*0.1F)
         analogInput = m_pController->GetAnalogMove();
-//    else if (m_pController->GetAnalogAim().GetMagnitude() > 0.1)
+//    else if (m_pController->GetAnalogAim().GetSqrMagnitude() > 0.1F*0.1F)
 //        analogInput = m_pController->GetAnalogAim();
 
     /////////////////////////////////////////////

--- a/Menus/AssemblyEditorGUI.cpp
+++ b/Menus/AssemblyEditorGUI.cpp
@@ -364,9 +364,9 @@ void AssemblyEditorGUI::Update()
     // Analog cursor input
 
     Vector analogInput;
-    if (m_pController->GetAnalogMove().GetMagnitude() > 0.1)
+    if (m_pController->GetAnalogMove().GetSqrMagnitude() > 0.1F*0.1F)
         analogInput = m_pController->GetAnalogMove();
-//    else if (m_pController->GetAnalogAim().GetMagnitude() > 0.1)
+//    else if (m_pController->GetAnalogAim().GetSqrMagnitude() > 0.1F*0.1F)
 //        analogInput = m_pController->GetAnalogAim();
 
     /////////////////////////////////////////////
@@ -682,7 +682,7 @@ void AssemblyEditorGUI::Update()
 						SceneObject *pBrain = g_SceneMan.GetScene()->GetResidentBrain(m_pController->GetPlayer());
 						if (pBrain)
 						{
-							if (g_SceneMan.ShortestDistance(pBrain->GetPos(), m_CursorPos,true).GetMagnitude() < 20)
+							if (g_SceneMan.ShortestDistance(pBrain->GetPos(), m_CursorPos,true).GetSqrMagnitude() < 20.0F*20.0F)
 							{
 								AHuman * pBrainAHuman = dynamic_cast<AHuman *>(pBrain);
 								if (pBrainAHuman)

--- a/Menus/GibEditorGUI.cpp
+++ b/Menus/GibEditorGUI.cpp
@@ -250,9 +250,9 @@ void GibEditorGUI::Update()
     // Analog cursor input
 
     Vector analogInput;
-    if (m_pController->GetAnalogMove().GetMagnitude() > 0.1)
+    if (m_pController->GetAnalogMove().GetSqrMagnitude() > 0.1F*0.1F)
         analogInput = m_pController->GetAnalogMove();
-//    else if (m_pController->GetAnalogAim().GetMagnitude() > 0.1)
+//    else if (m_pController->GetAnalogAim().GetSqrMagnitude() > 0.1F*0.1F)
 //        analogInput = m_pController->GetAnalogAim();
 
     /////////////////////////////////////////////

--- a/Menus/InventoryMenuGUI.cpp
+++ b/Menus/InventoryMenuGUI.cpp
@@ -1261,7 +1261,7 @@ namespace RTE {
 		auto LaunchInventoryItem = [this, &dropDirection](MovableObject *itemToLaunch) {
 			Vector itemPosition = m_InventoryActor->GetPos();
 			Vector throwForce(0.75F + (0.25F * RandomNum()), 0);
-			if (dropDirection && dropDirection->GetMagnitude() > 0.5F) {
+			if (dropDirection && dropDirection->GetSqrMagnitude() > 0.5F*0.5F) {
 				itemPosition += Vector(m_InventoryActor->GetRadius(), 0).AbsRotateTo(*dropDirection);
 				throwForce.SetX(throwForce.GetX() + 5.0F);
 				throwForce.AbsRotateTo(*dropDirection);

--- a/Menus/MetagameGUI.cpp
+++ b/Menus/MetagameGUI.cpp
@@ -687,7 +687,7 @@ void MetagameGUI::MoveLocationsIntoTheScreen()
 					Vector pos1 = (*pItr)->GetLocation() + (*pItr)->GetLocationOffset();
 					Vector pos2 = (*pItr2)->GetLocation() + (*pItr2)->GetLocationOffset();
 
-					if ((pos1 - pos2).GetMagnitude() < 8)
+					if ((pos1 - pos2).GetSqrMagnitude() < 8.0F*8.0F)
 					{
 						isOverlapped = true;
 						break;
@@ -1806,15 +1806,15 @@ void MetagameGUI::Update()
         }
 
         // Validate mouse position as being over the planet area for hover operations!
-        if (!m_pDraggedBox && (mousePos - m_PlanetCenter).GetMagnitude() < m_PlanetRadius)
+        if (!m_pDraggedBox && (mousePos - m_PlanetCenter).GetSqrMagnitude() < m_PlanetRadius*m_PlanetRadius)
         {
             // If unlocked, detect any Scene close to the mouse and highlight it
             bool foundAnyHover = false;
             bool foundNewHover = false;
             vector<Scene *>::iterator sItr;
             vector<Scene *>::iterator newCandidateItr = g_MetaMan.m_Scenes.end();
-            float distance = 0;
-            float shortestDist = 1000000.0;
+
+            float shortestDistSqr = std::numeric_limits<float>::infinity();
             for (sItr = g_MetaMan.m_Scenes.begin(); sItr != g_MetaMan.m_Scenes.end(); ++sItr)
             {
                 // Only mess with Scenes we can see
@@ -1822,13 +1822,13 @@ void MetagameGUI::Update()
                     continue;
 
                 screenLocation = m_PlanetCenter + (*sItr)->GetLocation() + (*sItr)->GetLocationOffset();
-                distance = (screenLocation - mousePos).GetMagnitude();
+                float sqrDistance = (screenLocation - mousePos).GetSqrMagnitude();
 
                 // The first new scene the mouse's position is close to when unlocked, make selected
-                if (distance < 16 && distance < shortestDist)
+                if (sqrDistance < 16.0F*16.0F && sqrDistance < shortestDistSqr)
                 {
                     // This is now the shortest
-                    shortestDist = distance;
+                    shortestDistSqr = sqrDistance;
                     foundAnyHover = true;
                     // See if the scene hovered is different from the previously hovered one, and if so, set it to the new candidate to switch hovering to
 // Actually, don't because it will cause alternating each frame if two hover zones overlap!

--- a/Menus/ScenarioGUI.cpp
+++ b/Menus/ScenarioGUI.cpp
@@ -278,8 +278,8 @@ namespace RTE {
 						Vector pos1 = sceneListEntry1->GetLocation() + sceneListEntry1->GetLocationOffset();
 						Vector pos2 = sceneListEntry2->GetLocation() + sceneListEntry2->GetLocationOffset();
 						Vector overlap = pos1 - pos2;
-						float overlapMagnitude = overlap.GetMagnitude();
-						if (overlapMagnitude < requiredDistance) {
+						float overlapMagnitudeSqr = overlap.GetSqrMagnitude();
+						if (overlapMagnitudeSqr < requiredDistance*requiredDistance) {
 							foundOverlap = true;
 							float overlapX = overlap.GetX();
 							float xDirMult = 0;
@@ -297,7 +297,7 @@ namespace RTE {
 							}
 							if (yDirMult != 0) {
 								sceneListEntry1->SetLocationOffset(sceneListEntry1->GetLocationOffset() + Vector(-overlapX + (requiredDistance * xDirMult), -overlapY + (requiredDistance * yDirMult)));
-							} else if (overlapMagnitude == 0.0F) {
+							} else if (overlapMagnitudeSqr == 0.0F) {
 								sceneListEntry1->SetLocationOffset(sceneListEntry1->GetLocationOffset() + Vector((pos1.GetX() > 0) ? -requiredDistance : requiredDistance, (pos1.GetY() > 0) ? -requiredDistance : requiredDistance));
 							} else {
 								sceneListEntry1->SetLocationOffset(sceneListEntry1->GetLocationOffset() + Vector(overlapX, overlapY));
@@ -427,11 +427,11 @@ namespace RTE {
 		bool foundAnyHover = false;
 		if (m_ActivityScenes && !m_DraggedBox && !m_ActivityInfoBox->PointInside(mouseX, mouseY) && !m_SceneInfoBox->PointInside(mouseX, mouseY)) {
 			Scene *candidateScene = nullptr;
-			float shortestDist = 10.0F;
+			float shortestDistSqr = 10.0F*10.0f;
 			for (Scene *activityScene : *m_ActivityScenes) {
-				float distance = (m_PlanetCenter + activityScene->GetLocation() + activityScene->GetLocationOffset() - Vector(static_cast<float>(mouseX), static_cast<float>(mouseY))).GetMagnitude();
-				if (distance < shortestDist) {
-					shortestDist = distance;
+				float sqrDistance = (m_PlanetCenter + activityScene->GetLocation() + activityScene->GetLocationOffset() - Vector(static_cast<float>(mouseX), static_cast<float>(mouseY))).GetSqrMagnitude();
+				if (sqrDistance < shortestDistSqr) {
+					shortestDistSqr = sqrDistance;
 					candidateScene = activityScene;
 					foundAnyHover = true;
 				}

--- a/Menus/SceneEditorGUI.cpp
+++ b/Menus/SceneEditorGUI.cpp
@@ -427,9 +427,9 @@ void SceneEditorGUI::Update()
     // Analog cursor input
 
     Vector analogInput;
-    if (m_pController->GetAnalogMove().GetMagnitude() > 0.1)
+    if (m_pController->GetAnalogMove().GetSqrMagnitude() > 0.1F*0.1F)
         analogInput = m_pController->GetAnalogMove();
-//    else if (m_pController->GetAnalogAim().GetMagnitude() > 0.1)
+//    else if (m_pController->GetAnalogAim().GetSqrMagnitude() > 0.1F*0.1F)
 //        analogInput = m_pController->GetAnalogAim();
 
     /////////////////////////////////////////////
@@ -978,7 +978,7 @@ void SceneEditorGUI::Update()
 								SceneObject *pBrain = g_SceneMan.GetScene()->GetResidentBrain(m_pController->GetPlayer());
 								if (pBrain)
 								{
-									if (g_SceneMan.ShortestDistance(pBrain->GetPos(), m_CursorPos,true).GetMagnitude() < 20)
+									if (g_SceneMan.ShortestDistance(pBrain->GetPos(), m_CursorPos,true).GetSqrMagnitude() < 20.0F*20.0F)
 									{
 										AHuman * pBrainAHuman = dynamic_cast<AHuman *>(pBrain);
 										if (pBrainAHuman)
@@ -1110,7 +1110,7 @@ void SceneEditorGUI::Update()
 									SceneObject *pBrain = g_SceneMan.GetScene()->GetResidentBrain(m_pController->GetPlayer());
 									if (pBrain)
 									{
-										if (g_SceneMan.ShortestDistance(pBrain->GetPos(), pPlacedClone->GetPos(),true).GetMagnitude() < 20)
+										if (g_SceneMan.ShortestDistance(pBrain->GetPos(), pPlacedClone->GetPos(),true).GetSqrMagnitude() < 20.0F*20.0F)
 										{
 											AHuman * pBrainAHuman = dynamic_cast<AHuman *>(pBrain);
 											if (pBrainAHuman)

--- a/System/Controller.cpp
+++ b/System/Controller.cpp
@@ -328,14 +328,14 @@ namespace RTE {
 		}
 
 		// If the joystick-controlled analog cursor is less than at the edge of input range, don't accelerate
-		if (GetAnalogCursor().GetMagnitude() < 0.85F) { m_JoyAccelTimer.Reset(); }
+		if (GetAnalogCursor().GetSqrMagnitude() < 0.85F*0.85F) { m_JoyAccelTimer.Reset(); }
 		// If the keyboard inputs for cursor movements is initially pressed, reset the acceleration timer
 		if (IsState(ACTOR_NEXT) || IsState(ACTOR_PREV) || (IsState(PRESS_LEFT) || IsState(PRESS_RIGHT) || IsState(PRESS_UP) || IsState(PRESS_DOWN))) {
 			m_KeyAccelTimer.Reset();
 		}
 
 		// Translate analog aim input into sharp aim control state
-		if (m_AnalogAim.GetMagnitude() > 0.1F && !m_ControlStates.at(PIE_MENU_ACTIVE)) { m_ControlStates.at(AIM_SHARP) = true; }
+		if (m_AnalogAim.GetSqrMagnitude() > 0.1F*0.1F && !m_ControlStates.at(PIE_MENU_ACTIVE)) { m_ControlStates.at(AIM_SHARP) = true; }
 
 		// Disable sharp aim while moving - this also helps with keyboard vs mouse fighting when moving and aiming in opposite directions
 		if (m_ControlStates.at(BODY_JUMP) || (pieMenuActive && !m_ControlStates.at(SECONDARY_ACTION))) {

--- a/System/Vector.cpp
+++ b/System/Vector.cpp
@@ -44,8 +44,8 @@ namespace RTE {
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 	Vector & Vector::CapMagnitude(const float capMag) {
-		if (capMag == 0) { Reset(); }
-		if (GetMagnitude() > capMag) { SetMagnitude(capMag); }
+		if (capMag == 0.0F) { Reset(); }
+		if (GetSqrMagnitude() > capMag*capMag) { SetMagnitude(capMag); }
 		return *this;
 	}
 
@@ -53,11 +53,12 @@ namespace RTE {
 
 	Vector & Vector::ClampMagnitude(float upperLimit, float lowerLimit) {
 		if (upperLimit < lowerLimit) { std::swap(upperLimit, lowerLimit); }
-		if (upperLimit == 0 && lowerLimit == 0) {
+		const float sqrMagnituge = GetSqrMagnitude();
+		if (upperLimit == 0.0F && lowerLimit == 0.0F) {
 			Reset();
-		} else if (GetMagnitude() > upperLimit) {
+		} else if (sqrMagnituge > upperLimit*upperLimit) {
 			SetMagnitude(upperLimit);
-		} else if (GetMagnitude() < lowerLimit) {
+		} else if (sqrMagnituge < lowerLimit*lowerLimit) {
 			SetMagnitude(lowerLimit);
 		}
 		return *this;

--- a/System/Vector.h
+++ b/System/Vector.h
@@ -145,10 +145,16 @@ namespace RTE {
 
 #pragma region Magnitude
 		/// <summary>
+		/// Gets the squared magnitude of this Vector.
+		/// </summary>
+		/// <returns>A float describing the squared magnitude.</returns>
+		float GetSqrMagnitude() const { return m_X*m_X + m_Y*m_Y; }
+
+		/// <summary>
 		/// Gets the magnitude of this Vector.
 		/// </summary>
 		/// <returns>A float describing the magnitude.</returns>
-		float GetMagnitude() const { return std::sqrt(std::pow(m_X, 2.0F) + std::pow(m_Y, 2.0F)); }
+		float GetMagnitude() const { return std::sqrt(m_X*m_X + m_Y*m_Y); }
 
 		/// <summary>
 		/// Sets the magnitude of this Vector. A negative magnitude will invert the Vector's direction.


### PR DESCRIPTION
… Y*Y is identical to X <Y. Removed a pointless costly call to the float overload of std::pow()